### PR TITLE
Fix automatic upgrades

### DIFF
--- a/resources/mattermost.rb
+++ b/resources/mattermost.rb
@@ -92,6 +92,18 @@ action :create do
     notifies :restart, 'osl_dockercompose[mattermost]'
   end
 
+  docker_image 'mattermost/mattermost-team-edition' do
+    tag new_resource.version
+    notifies :rebuild, 'osl_dockercompose[mattermost]'
+    notifies :restart, 'osl_dockercompose[mattermost]'
+  end
+
+  docker_image 'postgres' do
+    tag '13-alpine'
+    notifies :rebuild, 'osl_dockercompose[mattermost]'
+    notifies :restart, 'osl_dockercompose[mattermost]'
+  end
+
   cookbook_file '/usr/local/libexec/mattermost-backup.sh' do
     cookbook 'osl-mattermost'
     mode '0755'

--- a/spec/unit/resources/osl_mattermost_spec.rb
+++ b/spec/unit/resources/osl_mattermost_spec.rb
@@ -103,6 +103,16 @@ describe 'mattermost_test::default' do
     end
   end
 
+  it { is_expected.to pull_docker_image('mattermost/mattermost-team-edition').with(tag: '8.1') }
+  it { is_expected.to pull_docker_image('postgres').with(tag: '13-alpine') }
+  %w(
+    mattermost/mattermost-team-edition
+    postgres
+  ).each do |i|
+    it { expect(chef_run.docker_image(i)).to notify('osl_dockercompose[mattermost]').to(:rebuild) }
+    it { expect(chef_run.docker_image(i)).to notify('osl_dockercompose[mattermost]').to(:restart) }
+  end
+
   it do
     is_expected.to create_template('/var/lib/mattermost/.env').with(
       source: 'env.erb',


### PR DESCRIPTION
Use the docker_image resource to notify osl_dockercompose to rebuild/restart the
containers if there is a new image.

Signed-off-by: Lance Albertson <lance@osuosl.org>
