### PR TITLE
Add AlmaLinux 9

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,3 @@
-AllCops:
-  TargetChefVersion: 16.latest
 Chef/Modernize/FoodcriticComments:
   Enabled: true
 Chef/Style/CopyrightCommentFormat:

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -21,3 +21,7 @@ platforms:
     driver:
       image: dokken/almalinux-8
       pid_one_command: /usr/lib/systemd/systemd
+  - name: almalinux-9
+    driver:
+      image: dokken/almalinux-9
+      pid_one_command: /usr/lib/systemd/systemd

--- a/kitchen.openstack.yml
+++ b/kitchen.openstack.yml
@@ -25,4 +25,10 @@ platforms:
       image_ref: "AlmaLinux 8"
     transport:
       username: almalinux
+  - name: almalinux-9
+    driver_plugin: openstack
+    driver_config:
+      image_ref: "AlmaLinux 9"
+    transport:
+      username: almalinux
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -24,6 +24,7 @@ provisioner:
 
 platforms:
   - name: almalinux-8
+  - name: almalinux-9
 
 suites:
   - name: default

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,3 +15,4 @@ depends           'osl-git'
 depends           'osl-nginx'
 
 supports          'almalinux', '~> 8.0'
+supports          'almalinux', '~> 9.0'

--- a/spec/unit/resources/osl_mattermost_spec.rb
+++ b/spec/unit/resources/osl_mattermost_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
 
 describe 'mattermost_test::default' do
-  platform 'almalinux', '8'
+  platform 'almalinux'
   cached(:subject) { chef_run }
   step_into :osl_mattermost
 

--- a/test/integration/default/controls/default.rb
+++ b/test/integration/default/controls/default.rb
@@ -119,7 +119,13 @@ control 'default' do
     its('exit_status') { should eq 0 }
     its('stdout') { should eq '' }
     # This comes from upstream files not managed by Chef.
-    its('stderr') { should match %r{^time="[0-9]+-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+Z" level=warning msg="/var/lib/mattermost/docker-compose\.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"\n} }
+    if os.release.to_i >= 9
+      its('stderr') { should match %r{^time="[0-9]+-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+Z" level=warning msg="/var/lib/mattermost/docker-compose\.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"\n} }
+      its('stderr') { should match %r{^time="[0-9]+-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+Z" level=warning msg="/var/lib/mattermost/docker-compose\.without-nginx\.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"\n} }
+    else
+      its('stderr') { should match %r{^time="[0-9]+-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+Z" level=warning msg="/var/lib/mattermost/docker-compose\.yml: `version` is obsolete"\n} }
+      its('stderr') { should match %r{^time="[0-9]+-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+Z" level=warning msg="/var/lib/mattermost/docker-compose\.without-nginx\.yml: `version` is obsolete"\n} }
+    end
   end
 
   describe cron 'root' do

--- a/test/integration/default/controls/default.rb
+++ b/test/integration/default/controls/default.rb
@@ -118,7 +118,8 @@ control 'default' do
   describe command '/usr/local/libexec/mattermost-backup.sh' do
     its('exit_status') { should eq 0 }
     its('stdout') { should eq '' }
-    its('stderr') { should eq '' }
+    # This comes from upstream files not managed by Chef.
+    its('stderr') { should match /^time="[0-9]+-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+Z" level=warning msg="\/var\/lib\/mattermost\/docker-compose\.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"\n/ }
   end
 
   describe cron 'root' do

--- a/test/integration/default/controls/default.rb
+++ b/test/integration/default/controls/default.rb
@@ -119,7 +119,7 @@ control 'default' do
     its('exit_status') { should eq 0 }
     its('stdout') { should eq '' }
     # This comes from upstream files not managed by Chef.
-    its('stderr') { should match /^time="[0-9]+-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+Z" level=warning msg="\/var\/lib\/mattermost\/docker-compose\.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"\n/ }
+    its('stderr') { should match %r{^time="[0-9]+-[0-9]+-[0-9]+T[0-9]+:[0-9]+:[0-9]+Z" level=warning msg="/var/lib/mattermost/docker-compose\.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"\n} }
   end
 
   describe cron 'root' do


### PR DESCRIPTION
- Support AlmaLinux 9
- In the default integration test, catch the deprecated `version` parameter warning from the upstream docker-compose files