### PR TITLE
Migrate to using external postgresql server

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -11,6 +11,7 @@ cookbook 'osl-gpu', git: 'git@github.com:osuosl-cookbooks/osl-gpu', branch: 'mai
 cookbook 'osl-nginx', git: 'git@github.com:osuosl-cookbooks/osl-nginx'
 cookbook 'osl-nrpe', git: 'git@github.com:osuosl-cookbooks/osl-nrpe'
 cookbook 'osl-repos', git: 'git@github.com:osuosl-cookbooks/osl-repos'
+cookbook 'osl-postgresql', git: 'git@github.com:osuosl-cookbooks/osl-postgresql'
 cookbook 'osl-resources', git: 'git@github.com:osuosl-cookbooks/osl-resources', branch: 'main'
 cookbook 'osl-selinux', git: 'git@github.com:osuosl-cookbooks/osl-selinux'
 

--- a/files/docker-compose.yml
+++ b/files/docker-compose.yml
@@ -1,0 +1,35 @@
+# https://docs.docker.com/compose/environment-variables/
+services:
+  mattermost:
+    ports:
+      - ${APP_PORT}:8065
+      - ${CALLS_PORT}:${CALLS_PORT}/udp
+      - ${CALLS_PORT}:${CALLS_PORT}/tcp
+    image: mattermost/${MATTERMOST_IMAGE}:${MATTERMOST_IMAGE_TAG}
+    restart: ${RESTART_POLICY}
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 200
+    read_only: ${MATTERMOST_CONTAINER_READONLY}
+    tmpfs:
+      - /tmp
+    volumes:
+      - ${MATTERMOST_CONFIG_PATH}:/mattermost/config:rw
+      - ${MATTERMOST_DATA_PATH}:/mattermost/data:rw
+      - ${MATTERMOST_LOGS_PATH}:/mattermost/logs:rw
+      - ${MATTERMOST_PLUGINS_PATH}:/mattermost/plugins:rw
+      - ${MATTERMOST_CLIENT_PLUGINS_PATH}:/mattermost/client/plugins:rw
+      - ${MATTERMOST_BLEVE_INDEXES_PATH}:/mattermost/bleve-indexes:rw
+    environment:
+      # timezone inside container
+      - TZ
+
+      # necessary Mattermost options/variables (see env.example)
+      - MM_SQLSETTINGS_DRIVERNAME
+      - MM_SQLSETTINGS_DATASOURCE
+
+      # necessary for bleve
+      - MM_BLEVESETTINGS_INDEXDIR
+
+      # additional settings
+      - MM_SERVICESETTINGS_SITEURL

--- a/templates/env.erb
+++ b/templates/env.erb
@@ -8,18 +8,10 @@ DOMAIN=<%= @domain %>
 TZ=<%= @timezone %>
 RESTART_POLICY=unless-stopped
 
-# Postgres settings
-## Documentation for this image and available settings can be found on hub.docker.com
-## https://hub.docker.com/_/postgres
-## Please keep in mind this will create a superuser and it's recommended to use a less privileged
-## user to connect to the database.
-## A guide on how to change the database user to a nonsuperuser can be found in docs/creation-of-nonsuperuser.md
-POSTGRES_IMAGE_TAG=13-alpine
-POSTGRES_DATA_PATH=./volumes/db/var/lib/postgresql/data
-
-POSTGRES_USER=mmuser
-POSTGRES_PASSWORD=mmuser_password
-POSTGRES_DB=mattermost
+POSTGRES_HOST=<%= @db_host %>
+POSTGRES_USER=<%= @db_user %>
+POSTGRES_PASSWORD=<%= @db_password %>
+POSTGRES_DB=<%= @db_name %>
 
 # Nginx
 ## The nginx container will use a configuration found at the NGINX_MATTERMOST_CONFIG. The config aims
@@ -80,7 +72,7 @@ APP_PORT=8065
 
 ## Below one can find necessary settings to spin up the Mattermost container
 MM_SQLSETTINGS_DRIVERNAME=postgres
-MM_SQLSETTINGS_DATASOURCE=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable&connect_timeout=10
+MM_SQLSETTINGS_DATASOURCE=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:5432/${POSTGRES_DB}?sslmode=disable&connect_timeout=10
 
 ## Example settings (any additional setting added here also needs to be introduced in the docker-compose.yml)
 MM_SERVICESETTINGS_SITEURL=https://${DOMAIN}

--- a/test/cookbooks/mattermost_test/metadata.rb
+++ b/test/cookbooks/mattermost_test/metadata.rb
@@ -1,3 +1,4 @@
 name 'mattermost_test'
 version '0.1.0'
 depends 'osl-mattermost'
+depends 'osl-postgresql'

--- a/test/cookbooks/mattermost_test/recipes/default.rb
+++ b/test/cookbooks/mattermost_test/recipes/default.rb
@@ -1,1 +1,21 @@
-osl_mattermost 'mm.example.org'
+osl_postgresql_server 'mattermost' do
+  version '16'
+  access 'access'
+  osl_only false
+end
+
+postgresql_user 'mattermost' do
+  unencrypted_password 'mattermost'
+  login true
+end
+
+postgresql_database 'mattermost' do
+  owner 'mattermost'
+end
+
+osl_mattermost 'mm.example.org' do
+  db_host node['ipaddress']
+  db_user 'mattermost'
+  db_password 'mattermost'
+  db_name 'mattermost'
+end

--- a/test/integration/data_bags/postgres/access.json
+++ b/test/integration/data_bags/postgres/access.json
@@ -1,0 +1,16 @@
+{
+  "id": "access",
+  "resources": [
+    {
+      "name": "mattermost",
+      "resource": "postgresql_access",
+      "attributes": {
+        "type": "host",
+        "database": "mattermost",
+        "user": "mattermost",
+        "address": "all",
+        "auth_method": "scram-sha-256"
+      }
+    }
+  ]
+}

--- a/test/integration/default/controls/default.rb
+++ b/test/integration/default/controls/default.rb
@@ -41,11 +41,6 @@ control 'default' do
     its('image') { should eq 'mattermost/mattermost-team-edition:10.5' }
   end
 
-  describe docker_container 'mattermost-postgres-1' do
-    it { should be_running }
-    its('image') { should eq 'postgres:13-alpine' }
-  end
-
   describe command 'echo | openssl s_client -connect 127.0.0.1:443 -servername mm.example.org 2>/dev/null' do
     its('stdout') { should match(/CN ?= ?mm.example.org/) }
     its('stdout') { should match(/CN ?= ?Pebble Intermediate CA/) }
@@ -108,19 +103,5 @@ control 'default' do
     its('content') { should match /^MATTERMOST_IMAGE_TAG=10.5$/ }
     its('content') { should match /^DOMAIN=mm.example.org$/ }
     its('content') { should match /^TZ=UTC$/ }
-  end
-
-  describe file '/usr/local/libexec/mattermost-backup.sh' do
-    it { should exist }
-    its('mode') { should cmp '0755' }
-  end
-
-  describe command '/usr/local/libexec/mattermost-backup.sh' do
-    its('exit_status') { should eq 0 }
-    its('stdout') { should eq '' }
-  end
-
-  describe cron 'root' do
-    it { should have_entry '@daily /usr/local/libexec/mattermost-backup.sh' }
   end
 end


### PR DESCRIPTION
This removes the requirement of running a postgresql server inside of a
container. Instead, it requires an external postgresql server.

- Manually manage docker-compose.yml with our specific settings
- Add properties for db_host, db_name, db_password and db_user
- Remove backup solution

Signed-off-by: Lance Albertson <lance@osuosl.org>
