### PR TITLE
Remove redundant :restart notifications for osl_dockercompose

### DIFF
--- a/resources/mattermost.rb
+++ b/resources/mattermost.rb
@@ -98,13 +98,11 @@ action :create do
     )
     sensitive true
     notifies :rebuild, 'osl_dockercompose[mattermost]'
-    notifies :restart, 'osl_dockercompose[mattermost]'
   end
 
   docker_image 'mattermost/mattermost-team-edition' do
     tag new_resource.version
     notifies :rebuild, 'osl_dockercompose[mattermost]'
-    notifies :restart, 'osl_dockercompose[mattermost]'
   end
 
   osl_dockercompose 'mattermost' do

--- a/spec/unit/resources/osl_mattermost_spec.rb
+++ b/spec/unit/resources/osl_mattermost_spec.rb
@@ -105,7 +105,6 @@ describe 'mattermost_test::default' do
 
   it { is_expected.to pull_docker_image('mattermost/mattermost-team-edition').with(tag: '10.5') }
   it { expect(chef_run.docker_image('mattermost/mattermost-team-edition')).to notify('osl_dockercompose[mattermost]').to(:rebuild) }
-  it { expect(chef_run.docker_image('mattermost/mattermost-team-edition')).to notify('osl_dockercompose[mattermost]').to(:restart) }
 
   it do
     is_expected.to create_template('/var/lib/mattermost/.env').with(
@@ -126,5 +125,4 @@ describe 'mattermost_test::default' do
   end
 
   it { expect(chef_run.template('/var/lib/mattermost/.env')).to notify('osl_dockercompose[mattermost]').to(:rebuild) }
-  it { expect(chef_run.template('/var/lib/mattermost/.env')).to notify('osl_dockercompose[mattermost]').to(:restart) }
 end


### PR DESCRIPTION
The :restart action after :rebuild is redundant because :rebuild already
recreates and starts containers with the new configuration using
'docker compose up --pull always --build -d'.

Changes:
- Removed all :restart notifications for osl_dockercompose resources
- Updated Berksfile to use osl-docker branch with fixed helper method
- Removed corresponding spec tests for :restart notifications

Affected resources:
- template for .env file
- docker_image resource

The :rebuild action is sufficient as it:
- Pulls latest images
- Rebuilds containers if needed
- Recreates containers with new config
- Starts containers in detached mode

Signed-off-by: Lance Albertson <lance@osuosl.org>
